### PR TITLE
adding support for yrb bundle formats represented by *.pres files

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ Locator Lang Change History
 * using `/` instead of `.` for the delimiter when registering under `Y.Inlt`.
 * allows the application to declare the default language tag.
 * guarantees that build files will always include a language tag.
+* adding support for yrb format in a form of `*.pres` files.
 
 0.0.1-rc2 (2013-09-27)
 ------------------

--- a/example/lang/xyz.pres
+++ b/example/lang/xyz.pres
@@ -1,0 +1,43 @@
+# This is a test data file.
+    # It does not represent useful data.
+    # And it mixes languages
+#
+
+# note that whitespace is stripped, so the value of the
+# following entry really means
+# "1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월"
+
+MONTHS_SHORT = 1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월   
+
+# this is a twelve-line value
+
+MONTHS_LONG = <<< end
+1월
+2월
+3월
+4월
+5월
+6월
+# yes there are comments within heredocs
+    # and they don't have to start at the beginning of the line
+	# and they can use a tab as whitespace
+7월
+8월
+9월
+10월
+11월
+12월
+end;
+
+# this entry has all escape sequences, with an escaped space at the end
+
+ESCAPES = \ \\\n\t\#\ 
+
+KEY WITH SPACES = 1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월
+
+WITH QUOTES " = "
+
+EMPTY =
+
+EMPTY HEREDOC = <<< end
+end

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,6 +11,7 @@
 var libfs = require('fs'),
     libpath = require('path'),
     json5 = require('json5'),
+    yrb2json = require('./yrb2json'),
     description = require('../package.json').description,
 
     // This regex only validates the primary language subtag. Subsequent
@@ -30,7 +31,7 @@ function PluginClass(config) {
 
     this.describe = {
         summary: description,
-        extensions: ['js', 'json', 'json5'],
+        extensions: ['js', 'json', 'json5', 'pres'],
         options: config || {}
     };
 
@@ -70,10 +71,15 @@ PluginClass.prototype = {
         }
 
         return api.promise(function (fulfill, reject) {
-            var langEntries;
+            var langEntries,
+                source;
 
             try {
-                langEntries = json5.parse(libfs.readFileSync(source_path, 'utf8').toString());
+                source = libfs.readFileSync(source_path, 'utf8').toString();
+                if (file.ext === 'pres') {
+                    source = yrb2json(source);
+                }
+                langEntries = json5.parse(source);
             } catch (e) {
                 throw new Error('Error parsing lang bundle: ' +
                         file.relativePath, '. ' + e);

--- a/lib/yrb2json.js
+++ b/lib/yrb2json.js
@@ -1,0 +1,177 @@
+/**
+ * Converts resource bundles provided in YRB format into JSON format.
+ *
+ * YRB format is documented at
+ * http://developer.yahoo.com/yui/3/intl/index.html#yrb
+ *
+ * This implementation comes from one of our legacy components (builder):
+ * https://github.com/yui/builder/tree/master/componentbuild/lib/yrb2json
+ */
+
+/*jslint onevar: true, undef: true, nomen: true, eqeqeq: true, bitwise: true, regexp: true, newcap: true, immed: true */
+
+function isCommentLine(line) {
+    return (line.match(/^[ \t]*#/) !== null);
+}
+
+function isWhitespaceLine(line) {
+    return (line.match(/^[ \t]*$/) !== null);
+}
+
+function isWhitespaceChar(c) {
+    return c === " " || c === "\t";
+}
+
+/**
+ * Checks whether the given key is not empty and doesn't contain backslashes.
+ */
+function checkKey(key) {
+    if (key.length === 0) {
+        throw new Error("Empty key not allowed.");
+    }
+    if (key.indexOf("\\") >= 0) {
+        throw new Error("Backslash not allowed in key: " + key);
+    }
+}
+
+function trimWhitespace(s) {
+    var start = 0, end = s.length;
+    while (start < s.length && isWhitespaceChar(s.charAt(start))) {
+        start++;
+    }
+    while (end > start && isWhitespaceChar(s.charAt(end - 1))) {
+        end--;
+    }
+    return s.substring(start, end);
+}
+
+/**
+ * Unescapes all escape sequences that occur in s. Optionally trims whitespace
+ * from beginning and end of string, taking care not to trim whitespace
+ * that's part of an escape sequence.
+ */
+function unescapeValue(s, trim) {
+    var pos, start, end, result;
+
+    pos = s.indexOf("\\");
+    if (pos >= 0) {
+        result = "";
+        start = 0;
+        if (trim) {
+            while (isWhitespaceChar(s.charAt(start))) {
+                start++;
+            }
+        }
+        while (pos >= 0) {
+            result += s.substring(start, pos);
+            if (pos + 1 >= s.length) {
+                throw new Error("Illegal escape sequence: unaccompanied \\");
+            }
+            switch (s.charAt(pos + 1)) {
+                case "\\":
+                    result += "\\";
+                    break;
+                case "n":
+                    result += "\n";
+                    break;
+                case "t":
+                    result += "\t";
+                    break;
+                case " ":
+                    result += " ";
+                    break;
+                case "#":
+                    result += "#";
+                    break;
+                default:
+                    throw new Error("Illegal escape sequence: \\" + s.charAt(pos + 1));
+            }
+            start = pos + 2;
+            pos = s.indexOf("\\", start);
+        }
+        end = s.length;
+        if (trim) {
+            while (end > start && isWhitespaceChar(s.charAt(end - 1))) {
+                end--;
+            }
+        }
+        result += s.substring(start, end);
+    } else {
+        result = trim ? trimWhitespace(s) : s;
+    }
+    return result;
+}
+
+/**
+ * Convert a string into JSON representation. Should use stringify once Rhino gets it.
+ */
+function jsonString(s) {
+    return "\"" + s.replace(/\\/g, "\\\\").replace(/\"/g, "\\\"").replace(/\n/g, "\\n").replace(/\t/g, "\\t") + "\"";
+}
+
+function jsonKeyValue(key, value) {
+    return jsonString(key) + ":" + jsonString(value);
+}
+
+/**
+ * Converts the contents of one YRB file into corresponding JSON content.
+ */
+module.exports = function (source) {
+    var lines, properties, hereDocId, i, line, equalsPos, key, remainder,
+        match, value;
+
+    if (source.length > 0 && source.charAt(0) === "\ufeff") {
+        // remove BOM
+        source = source.substring(1);
+    }
+    lines = source.replace(/\r\n/g, '\n').replace(/\r/g, '\n').split('\n');
+
+    properties = [];
+    hereDocId = null; // null indicates we're not inside heredoc section
+
+    for (i = 0; i < lines.length; i++) {
+        line = lines[i];
+        if (isCommentLine(line)) {
+            continue;
+        }
+        if (hereDocId === null) {
+            if (isWhitespaceLine(line)) {
+                continue;
+            }
+
+            // extract the key
+            equalsPos = line.indexOf("=");
+            if (equalsPos < 0) {
+                throw new Error("Missing '=' in line " + line + ".");
+            }
+            key = trimWhitespace(line.substring(0, equalsPos));
+            checkKey(key);
+
+            // decide whether it's simple or heredoc form
+            remainder = line.substring(equalsPos + 1);
+            if ((match = remainder.match(/^[ \t]*<<</)) !== null) {
+                hereDocId = trimWhitespace(remainder.substring(match[0].length));
+                value = null;
+            } else {
+                value = unescapeValue(remainder, true);
+                properties.push(jsonKeyValue(key, value));
+            }
+        } else {
+            if (line === hereDocId || line === hereDocId + ";") {
+                value = value || "";
+                properties.push(jsonKeyValue(key, value));
+                hereDocId = null;
+            } else {
+                if (value === null) {
+                    value = unescapeValue(line, false);
+                } else {
+                    value += "\n" + unescapeValue(line, false);
+                }
+            }
+        }
+    }
+    if (hereDocId !== null) {
+        throw new Error("Incomplete heredoc with id " + hereDocId + ".");
+    }
+    return '{' + properties.join(",") + "}";
+};


### PR DESCRIPTION
This PR will extend the capabilities of `locator-lang` to support `*.pres` files with the format described here:

http://developer.yahoo.com/yui/3/intl/index.html#yrb

And the parser comes from the builder component (a legacy component):

https://github.com/yui/builder/tree/master/componentbuild/lib/yrb2json

Here is an example of the transformation for a file called `xyz.pres` with this content:

```
# This is a test data file.
    # It does not represent useful data.
    # And it mixes languages
#

# note that whitespace is stripped, so the value of the
# following entry really means
# "1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월"

MONTHS_SHORT = 1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월   

# this is a twelve-line value

MONTHS_LONG = <<< end
1월
2월
3월
4월
5월
6월
# yes there are comments within heredocs
    # and they don't have to start at the beginning of the line
    # and they can use a tab as whitespace
7월
8월
9월
10월
11월
12월
end;

# this entry has all escape sequences, with an escaped space at the end

ESCAPES = \ \\\n\t\#\ 

KEY WITH SPACES = 1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월

WITH QUOTES " = "

EMPTY =

EMPTY HEREDOC = <<< end
end
```

the output is going to be:

```
YUI.add("demo-lang-xyz",function(Y, NAME){
   Y.Intl.add("demo/xyz", "en", {"MONTHS_SHORT":"1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월","MONTHS_LONG":"1월\n2월\n3월\n4월\n5월\n6월\n7월\n8월\n9월\n10월\n11월\n12월","ESCAPES":" \\\n\t# ","KEY WITH SPACES":"1월, 2월, 3월, 4월, 5월, 6월, 7월, 8월, 9월, 10월, 11월, 12월","WITH QUOTES \"":"\"","EMPTY":"","EMPTY HEREDOC":""});
}, "", {requires: ["intl"]});
```
