### PR TITLE
supporting whitelist of langs to fallback lang bundles and lang entries when needed

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@ Locator Lang Change History
 @NEXT@
 ------------------
 
-* PR #6: supporting whitelist of langs to fallback lang bundles and lang entries when needed
+* PR #6: supporting requiredLangs of langs to fallback lang bundles and lang entries when needed
 
 0.1.2 (2014-02-13)
 ------------------

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ Locator Lang Change History
 @NEXT@
 ------------------
 
+* PR #6: supporting whitelist of langs to fallback lang bundles and lang entries when needed
+
 0.1.2 (2014-02-13)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage
 
 The examples below show how to use the plugin with locator.
 
-### Compiling language bundles into memory
+### Compiling language bundles
 
 ```
 var Locator = require('locator'),
@@ -53,7 +53,9 @@ This example compiles any lang file into memory and exposes it through
 - `langBundleName` is derived from the file name from where the language
   entries were extracted.
 
-### Compiling language bundles into YUI modules
+### Configuration Options
+
+There are few configuration arguments that can be passed when creating a plugin instance. Here is an example:
 
 ```
 var Locator = require('locator'),
@@ -61,13 +63,18 @@ var Locator = require('locator'),
     loc = new Locator({ buildDirectory: 'build' });
 
 // using locator-lang plugin
-loc.plug(new LocatorLang({ format: 'yui' }));
+loc.plug(new LocatorLang({
+	format: 'yui',
+	defaultLang: 'en',
+    transpiler: 'yrb',
+    whitelist: ['en', 'es', 'fr']
+}));
 ```
 
-In this example, each language bundle will be compiled into files containing
-[YUI][] modules under the `build` folder.
+#### `transpiler` configuration
 
-# YRB Transpiler
+As today, only one transpiler called `yrb` is supported, by default it will apply
+a simple `JSON.parse`.
 
 YRB pattern strings are externalized into resource bundles and localized by
 translators, while the arguments and locale are provided by the software at
@@ -81,6 +88,20 @@ are ultimately used to fill localized templates.
 
 [intl-messageformat]: http://github.com/yahoo/intl-messageformat
 [language resource bundles]: http://yuilibrary.com/yui/docs/intl/index.html#yrb
+
+#### `format` configuration
+
+The only format supported as today is `yui`. In this example above, each language bundle will be compiled into files containing [YUI][] modules under the `build` folder.
+
+#### `defaultLang` configuration
+
+This value defines what language to use when a lang bundle source file does not
+include the locale as part of the filename. In this example above, for a file like
+`path/lang/foo.json`, a new file will be generated as `foo_en.js`.
+
+#### `whitelist` configuration
+
+The `whitelist` configuration specifies an array of required language bundles. If this value is set, the plugin will complete those language bundles and/or entries in each bundle based on the `defaultLang`. In other words, if you haven't done the translation for a particular languange, the plugin will fallback to the default language bundle by using those values as the values for the missing language. The same happen for individual entries in each language bundle, and the plugin will be able to analyze each file, and fallback to default entries when needed. This guarentee that your application can assume all entries and lang bundles are in place for all the languages in the whitelist configuration.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ loc.plug(new LocatorLang({
 	format: 'yui',
 	defaultLang: 'en',
     transpiler: 'yrb',
-    whitelist: ['en', 'es', 'fr']
+    requiredLangs: ['en', 'es', 'fr']
 }));
 ```
 
@@ -99,9 +99,9 @@ This value defines what language to use when a lang bundle source file does not
 include the locale as part of the filename. In this example above, for a file like
 `path/lang/foo.json`, a new file will be generated as `foo_en.js`.
 
-#### `whitelist` configuration
+#### `requiredLangs` configuration
 
-The `whitelist` configuration specifies an array of required language bundles. If this value is set, the plugin will complete those language bundles and/or entries in each bundle based on the `defaultLang`. In other words, if you haven't done the translation for a particular languange, the plugin will fallback to the default language bundle by using those values as the values for the missing language. The same happen for individual entries in each language bundle, and the plugin will be able to analyze each file, and fallback to default entries when needed. This guarentee that your application can assume all entries and lang bundles are in place for all the languages in the whitelist configuration.
+The `requiredLangs` configuration specifies an array of required language bundles. If this value is set, the plugin will complete those language bundles and/or entries in each bundle based on the `defaultLang`. In other words, if you haven't done the translation for a particular languange, the plugin will fallback to the default language bundle by using those values as the values for the missing language. The same happen for individual entries in each language bundle, and the plugin will be able to analyze each file, and fallback to default entries when needed. This guarentee that your application can assume all entries and lang bundles are in place for all the languages in the requiredLangs configuration.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The examples below show how to use the plugin with locator.
 
 ### Compiling language bundles
 
-```
+```javascript
 var Locator = require('locator'),
     LocatorLang = require('locator-lang'),
     loc = new Locator();
@@ -57,7 +57,7 @@ This example compiles any lang file into memory and exposes it through
 
 There are few configuration arguments that can be passed when creating a plugin instance. Here is an example:
 
-```
+```javascript
 var Locator = require('locator'),
     LocatorLang = require('locator-lang'),
     loc = new Locator({ buildDirectory: 'build' });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -165,12 +165,12 @@ PluginClass.prototype = {
     },
 
     _completeMissing: function (bundle) {
-        var whitelist = this.describe.options.whitelist,
+        var requiredLangs = this.describe.options.requiredLangs,
             defaultLang = this.describe.options.defaultLang,
             files = [];
 
-        if (whitelist) {
-            whitelist.forEach(function (lang) {
+        if (requiredLangs) {
+            requiredLangs.forEach(function (lang) {
 
                 var defaultLangBundle = bundle.lang[defaultLang],
                     token,

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -48,23 +48,23 @@ PluginClass.prototype = {
         var file = evt.file,
             bundle = evt.bundle,
             source_path = file.fullPath,
-            filename = libpath.basename(file.relativePath, '.' + file.ext),
+            filename = this._getLangBundleName(source_path),
             transpiler = this.describe.options.transpiler,
             defaultLang = this.describe.options.defaultLang,
             langBundleName,
             match,
             lang;
 
+        // only lang files should be analyzed
+        if (!filename) {
+            return;
+        }
+
         match = filename.match(LANG_TAG_RE);
         lang  = (match && match[0].slice(1)) || defaultLang;
 
         // hoge_ja-JP => hoge
         langBundleName = filename.replace(LANG_TAG_RE, '');
-
-        // only files within the lang folder will be evaluated as lang bundles
-        if (libpath.basename(libpath.dirname(source_path)) !== 'lang') {
-            return;
-        }
 
         return new Promise(function (fulfill) {
             var langEntries,
@@ -102,14 +102,26 @@ PluginClass.prototype = {
 
     bundleUpdated: function (evt, api) {
         var bundle = evt.bundle,
-            bundleName = bundle.bundleName,
+            bundleName = bundle.name,
             format = this.describe.options.format,
-            promises = [];
+            formatter = require('./formats/' + format),
+            promises = [],
+            files = [];
 
         if (!bundle.lang) {
             return; // no lang bundle to be process
         }
 
+        Object.keys(evt.files).forEach(function (file) {
+            file = this._getLangBundleName(file);
+            if (file) {
+                files.push(file);
+            }
+        }, this);
+
+        if (files.length === 0) {
+            return; // no lang bundle where changed
+        }
         this._completeMissing(bundle);
 
         Object.keys(bundle.lang).forEach(function (lang) {
@@ -119,18 +131,25 @@ PluginClass.prototype = {
                 var moduleName = (bundleName + '-lang-' + langBundleName).toLocaleLowerCase(),
                     destination_path = moduleName + '_' + lang + '.js';
 
-                promises.push(new Promise(function (fulfill, reject) {
+                // generating the lang bundles that were modified
+                if (files.indexOf(langBundleName + '_' + lang) >= 0) {
                     // trying to write the destination file which the content of the lang bundle
-                    api.writeFileInBundle(bundleName, destination_path,
-                        require('./formats/' + format)(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang))
-                        .then(fulfill, reject);
-                }));
+                    promises.push(api.writeFileInBundle(
+                        bundleName,
+                        destination_path,
+                        formatter(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang)
+                    ));
+                }
 
             });
 
         });
+    },
 
-        return Promise.all(promises);
+    _getLangBundleName: function (file) {
+        var name = libpath.basename(file, libpath.extname(file));
+        // only files within the lang folder will be evaluated as lang bundles
+        return (libpath.basename(libpath.dirname(file)) === 'lang') && name;
     },
 
     _completeMissing: function (bundle) {
@@ -153,6 +172,12 @@ PluginClass.prototype = {
                         // if a lang bundle is missing in a particular lang
                         bundle.lang[lang][bundleName] = bundle.lang[lang][bundleName]
                                 || defaultLangBundle[bundleName];
+
+                        // simple process to avoid completing over and over again
+                        if (bundle.lang[lang][bundleName]['@expanded']) {
+                            continue;
+                        }
+                        Object.defineProperty(bundle.lang[lang][bundleName], '@expanded', { value: true });
 
                         for (token in defaultLangBundle[bundleName]) {
                             if (defaultLangBundle[bundleName].hasOwnProperty(token)) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -188,6 +188,7 @@ PluginClass.prototype = {
                             debug('lang bundle "%s" is missing for lang "%s", replicating from default "%s"', bundleName, lang, defaultLang);
                             bundle.lang[lang][bundleName] = defaultLangBundle[bundleName];
                             files.push(bundleName + '_' + lang);
+                            continue;
                         }
 
                         // simple process to avoid completing over and over again

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,6 +11,7 @@
 var libfs = require('fs'),
     libpath = require('path'),
     json5 = require('json5'),
+    Promise = require('ypromise'),
     yrb2json = require('./yrb2json'),
     description = require('../package.json').description,
 
@@ -29,28 +30,27 @@ var libfs = require('fs'),
 
 function PluginClass(config) {
 
+    config = config || {};
+    config.defaultLang = config.defaultLang || 'en';
+
     this.describe = {
         summary: description,
         extensions: ['js', 'json', 'json5', 'pres'],
-        options: config || {}
+        options: config
     };
 
 }
 
 PluginClass.prototype = {
 
-    fileUpdated: function (evt, api) {
+    fileUpdated: function (evt) {
 
         var file = evt.file,
             bundle = evt.bundle,
             source_path = file.fullPath,
-            bundleName = file.bundleName,
             filename = libpath.basename(file.relativePath, '.' + file.ext),
-            moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase(),
-            format = this.describe.options.format,
             transpiler = this.describe.options.transpiler,
-            defaultLang = this.describe.options.defaultLang || 'en',
-            destination_path,
+            defaultLang = this.describe.options.defaultLang,
             langBundleName,
             match,
             lang;
@@ -60,18 +60,13 @@ PluginClass.prototype = {
 
         // hoge_ja-JP => hoge
         langBundleName = filename.replace(LANG_TAG_RE, '');
-
-        // Guarantee that build files will always include lang tags.
-        // hoge => hoge_ja-JP.js
-        // piyo_ja-JP => piyo_ja-JP.js
-        destination_path = moduleName + (match ? '' : '_' + defaultLang) + '.js';
-
+console.log(filename, lang, langBundleName);
         // only files within the lang folder will be evaluated as lang bundles
         if (libpath.basename(libpath.dirname(source_path)) !== 'lang') {
             return;
         }
 
-        return api.promise(function (fulfill, reject) {
+        return new Promise(function (fulfill) {
             var langEntries,
                 source,
                 token;
@@ -100,17 +95,79 @@ PluginClass.prototype = {
             bundle.lang[lang] = bundle.lang[lang] || {};
             bundle.lang[lang][langBundleName] = langEntries;
 
-            if (format) {
-                // trying to write the destination file which will fulfill or reject the initial promise
-                api.writeFileInBundle(bundleName, destination_path,
-                    require('./formats/' + format)(bundleName, langBundleName, moduleName, langEntries, lang))
-                    .then(fulfill, reject);
-            } else {
-                fulfill();
-            }
+            fulfill();
+        });
+
+    },
+
+    bundleUpdated: function (evt, api) {
+        var bundle = evt.bundle,
+            bundleName = bundle.bundleName,
+            format = this.describe.options.format,
+            promises = [];
+
+        if (!bundle.lang) {
+            return; // no lang bundle to be process
+        }
+
+        this._completeMissing(bundle);
+
+        Object.keys(bundle.lang).forEach(function (lang) {
+
+            Object.keys(bundle.lang[lang]).forEach(function (langBundleName) {
+
+                var moduleName = (bundleName + '-lang-' + langBundleName).toLocaleLowerCase(),
+                    destination_path = moduleName + '_' + lang + '.js';
+
+                promises.push(new Promise(function (fulfill, reject) {
+                    // trying to write the destination file which the content of the lang bundle
+                    api.writeFileInBundle(bundleName, destination_path,
+                        require('./formats/' + format)(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang))
+                        .then(fulfill, reject);
+                }));
+
+            });
 
         });
 
+        return Promise.all(promises);
+    },
+
+    _completeMissing: function (bundle) {
+        var whitelist = this.describe.options.whitelist,
+            defaultLang = this.describe.options.defaultLang;
+
+        if (whitelist) {
+            whitelist.forEach(function (lang) {
+
+                var defaultLangBundle = bundle.lang[defaultLang],
+                    token,
+                    bundleName;
+
+                // if the entire lang is missing
+                bundle.lang[lang] = bundle.lang[lang] || defaultLangBundle;
+
+                for (bundleName in defaultLangBundle) {
+                    if (defaultLangBundle.hasOwnProperty(bundleName)) {
+
+                        // if a lang bundle is missing in a particular lang
+                        bundle.lang[lang][bundleName] = bundle.lang[lang][bundleName]
+                                || defaultLangBundle[bundleName];
+
+                        for (token in defaultLangBundle[bundleName]) {
+                            if (defaultLangBundle[bundleName].hasOwnProperty(token)) {
+
+                                // if a token is missing in a particular lang and particula lang bundle
+                                bundle.lang[lang][bundleName][token] = bundle.lang[lang][bundleName][token]
+                                        || defaultLangBundle[bundleName][token];
+                            }
+                        }
+
+                    }
+                }
+
+            });
+        }
     }
 
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -60,7 +60,7 @@ PluginClass.prototype = {
 
         // hoge_ja-JP => hoge
         langBundleName = filename.replace(LANG_TAG_RE, '');
-console.log(filename, lang, langBundleName);
+
         // only files within the lang folder will be evaluated as lang bundles
         if (libpath.basename(libpath.dirname(source_path)) !== 'lang') {
             return;

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,6 +13,7 @@ var libfs = require('fs'),
     json5 = require('json5'),
     Promise = require('ypromise'),
     yrb2json = require('./yrb2json'),
+    debug = require('debug')('locator-lang:plugin'),
     description = require('../package.json').description,
 
     // This regex only validates the primary language subtag. Subsequent
@@ -129,19 +130,28 @@ PluginClass.prototype = {
 
             Object.keys(bundle.lang[lang]).forEach(function (langBundleName) {
 
-                var moduleName = (bundleName + '-lang-' + langBundleName).toLocaleLowerCase(),
-                    destination_path = moduleName + '_' + lang + '.js';
+                var filename,
+                    moduleName,
+                    destination_path;
 
-                // generating the lang bundles that were modified
-                if ((files.indexOf(langBundleName + '_' + lang) >= 0) ||
-                    (lang === defaultLang && files.indexOf(langBundleName) >= 0)) {
-                    // trying to write the destination file which the content of the lang bundle
-                    promises.push(api.writeFileInBundle(
-                        bundleName,
-                        destination_path,
-                        formatter(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang)
-                    ));
+                if (files.indexOf(langBundleName + '_' + lang) >= 0) {
+                    filename = langBundleName + '_' + lang;
+                } else if (lang === defaultLang && files.indexOf(langBundleName) >= 0) {
+                    filename = langBundleName;
+                } else {
+                    return; // nothing to write since the lang bundle is not changed in this evt
                 }
+
+                moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase(),
+                destination_path = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
+
+                debug('writting lang bundle "%s" in lang "%s"', langBundleName, lang);
+                // trying to write the destination file which the content of the lang bundle
+                promises.push(api.writeFileInBundle(
+                    bundleName,
+                    destination_path,
+                    formatter(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang)
+                ));
 
             });
 
@@ -165,15 +175,18 @@ PluginClass.prototype = {
                     token,
                     bundleName;
 
-                // if the entire lang is missing
-                bundle.lang[lang] = bundle.lang[lang] || defaultLangBundle;
+                if (!bundle.lang[lang]) {
+                    debug('entire locale is missing for lang "%s", replicating from default "%s"', lang, defaultLang);
+                    bundle.lang[lang] = defaultLangBundle;
+                }
 
                 for (bundleName in defaultLangBundle) {
                     if (defaultLangBundle.hasOwnProperty(bundleName)) {
 
-                        // if a lang bundle is missing in a particular lang
-                        bundle.lang[lang][bundleName] = bundle.lang[lang][bundleName]
-                                || defaultLangBundle[bundleName];
+                        if (!bundle.lang[lang][bundleName]) {
+                            debug('lang bundle "%s" is missing for lang "%s", replicating from default "%s"', bundleName, lang, defaultLang);
+                            bundle.lang[lang][bundleName] = defaultLangBundle[bundleName];
+                        }
 
                         // simple process to avoid completing over and over again
                         if (bundle.lang[lang][bundleName]['@expanded']) {
@@ -184,9 +197,11 @@ PluginClass.prototype = {
                         for (token in defaultLangBundle[bundleName]) {
                             if (defaultLangBundle[bundleName].hasOwnProperty(token)) {
 
-                                // if a token is missing in a particular lang and particula lang bundle
-                                bundle.lang[lang][bundleName][token] = bundle.lang[lang][bundleName][token]
-                                        || defaultLangBundle[bundleName][token];
+                                if (!bundle.lang[lang][bundleName][token]) {
+                                    debug('lang entry "%s" is missing in bundle "%s" for lang "%s",' +
+                                          ' replicating from default "%s"', token, bundleName, lang, defaultLang);
+                                    bundle.lang[lang][bundleName][token] = defaultLangBundle[bundleName][token];
+                                }
                             }
                         }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -105,6 +105,7 @@ PluginClass.prototype = {
             bundleName = bundle.name,
             format = this.describe.options.format,
             formatter = require('./formats/' + format),
+            defaultLang = this.describe.options.defaultLang,
             promises = [],
             files = [];
 
@@ -132,7 +133,8 @@ PluginClass.prototype = {
                     destination_path = moduleName + '_' + lang + '.js';
 
                 // generating the lang bundles that were modified
-                if (files.indexOf(langBundleName + '_' + lang) >= 0) {
+                if ((files.indexOf(langBundleName + '_' + lang) >= 0) ||
+                    (lang === defaultLang && files.indexOf(langBundleName) >= 0)) {
                     // trying to write the destination file which the content of the lang bundle
                     promises.push(api.writeFileInBundle(
                         bundleName,

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -132,7 +132,7 @@ PluginClass.prototype = {
 
                 var filename,
                     moduleName,
-                    destination_path;
+                    destinationPath;
 
                 if (files.indexOf(langBundleName + '_' + lang) >= 0) {
                     filename = langBundleName + '_' + lang;
@@ -143,13 +143,13 @@ PluginClass.prototype = {
                 }
 
                 moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase(),
-                destination_path = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
+                destinationPath = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
 
-                debug('writting [%s] in lang "%s"', destination_path, lang);
+                debug('writting [%s] in lang "%s"', destinationPath, lang);
                 // trying to write the destination file which the content of the lang bundle
                 promises.push(api.writeFileInBundle(
                     bundleName,
-                    destination_path,
+                    destinationPath,
                     formatter(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang)
                 ));
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -124,7 +124,7 @@ PluginClass.prototype = {
         if (files.length === 0) {
             return; // no lang bundle where changed
         }
-        this._completeMissing(bundle);
+        files = files.concat(this._completeMissing(bundle));
 
         Object.keys(bundle.lang).forEach(function (lang) {
 
@@ -145,7 +145,7 @@ PluginClass.prototype = {
                 moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase(),
                 destination_path = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
 
-                debug('writting lang bundle "%s" in lang "%s"', langBundleName, lang);
+                debug('writting [%s] in lang "%s"', destination_path, lang);
                 // trying to write the destination file which the content of the lang bundle
                 promises.push(api.writeFileInBundle(
                     bundleName,
@@ -166,7 +166,8 @@ PluginClass.prototype = {
 
     _completeMissing: function (bundle) {
         var whitelist = this.describe.options.whitelist,
-            defaultLang = this.describe.options.defaultLang;
+            defaultLang = this.describe.options.defaultLang,
+            files = [];
 
         if (whitelist) {
             whitelist.forEach(function (lang) {
@@ -176,8 +177,8 @@ PluginClass.prototype = {
                     bundleName;
 
                 if (!bundle.lang[lang]) {
-                    debug('entire locale is missing for lang "%s", replicating from default "%s"', lang, defaultLang);
-                    bundle.lang[lang] = defaultLangBundle;
+                    debug('entire locale is missing for lang "%s"', lang);
+                    bundle.lang[lang] = {};
                 }
 
                 for (bundleName in defaultLangBundle) {
@@ -186,6 +187,7 @@ PluginClass.prototype = {
                         if (!bundle.lang[lang][bundleName]) {
                             debug('lang bundle "%s" is missing for lang "%s", replicating from default "%s"', bundleName, lang, defaultLang);
                             bundle.lang[lang][bundleName] = defaultLangBundle[bundleName];
+                            files.push(bundleName + '_' + lang);
                         }
 
                         // simple process to avoid completing over and over again
@@ -210,6 +212,7 @@ PluginClass.prototype = {
 
             });
         }
+        return files;
     }
 
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "json5": "~0.2.0",
         "intl": "~0.1.1",
         "intl-messageformat": "0.1.0-rc-1",
-        "ypromise": "^0.2.3"
+        "ypromise": "^0.2.3",
+        "debug": "^0.7.4"
     },
     "devDependencies": {
         "chai": "*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dependencies": {
         "json5": "~0.2.0",
         "intl": "~0.1.1",
-        "intl-messageformat": "0.1.0-rc-1"
+        "intl-messageformat": "0.1.0-rc-1",
+        "ypromise": "^0.2.3"
     },
     "devDependencies": {
         "chai": "*",

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -126,7 +126,7 @@ describe('Plugin', function () {
                     }
                 },
                 files: {
-                    "path/to/lang/user_en.json": {}
+                    "path/to/lang/user.json": {}
                 }
             };
 
@@ -157,6 +157,7 @@ describe('Plugin', function () {
             });
 
             it('allows for a configurable default lang tag missing', function () {
+                evt.files["path/to/lang/user_en.json"] = {}; // regular english file
                 new Plugin({
                     defaultLang: 'ja-JP',
                     format: FORMAT

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -166,10 +166,10 @@ describe('Plugin', function () {
                 assert.equal(output['app/app-lang-user_en.js'].indexOf('{"foo":"FOO","bar":"BAR","baz":"BAZ"}') > 0, true);
             });
 
-            it('allows whitelist bundle fallback', function () {
+            it('allows requiredLangs bundle fallback', function () {
                 evt.files["path/to/lang/user_fr.json"] = {};
                 new Plugin({
-                    whitelist: ['en', 'fr'],
+                    requiredLangs: ['en', 'fr'],
                     format: FORMAT
                 }).bundleUpdated(evt, api);
                 assert.equal(Object.keys(output).length, 2);
@@ -177,7 +177,7 @@ describe('Plugin', function () {
                 assert.equal(output['app/app-lang-user_fr.js'].indexOf('{"foo":"FOO","bar":"BAR","baz":"BAZ"}') > 0, true);
             });
 
-            it('allows whitelist entry fallback', function () {
+            it('allows requiredLangs entry fallback', function () {
                 evt.bundle.lang.fr = {
                     user: {
                         foo: 'FOO-IN-FRENCH'
@@ -186,7 +186,7 @@ describe('Plugin', function () {
                 evt.files["path/to/lang/user_fr.json"] = {};
                 evt.files["path/to/lang/user_cu.json"] = {};
                 new Plugin({
-                    whitelist: ['en', 'fr'],
+                    requiredLangs: ['en', 'fr'],
                     format: FORMAT
                 }).bundleUpdated(evt, api);
                 assert.equal(Object.keys(output).length, 2);

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -38,14 +38,6 @@ describe('Plugin', function () {
                     };
                 }
             });
-            mockery.registerMock('path', {
-                basename: function (basename) {
-                    return basename;
-                },
-                dirname: function (dirname) {
-                    return dirname;
-                }
-            });
             mockery.registerMock('json5', {
                 parse: function () {
                     return LANG_ENTRIES;
@@ -65,8 +57,8 @@ describe('Plugin', function () {
             evt = {
                 file: {
                     ext: 'json',
-                    fullPath: 'lang',
-                    bundleName: 'bundlename',
+                    fullPath: 'path/to/lang/filename.json',
+                    name: 'bundlename',
                     relativePath: 'filename'
                 },
                 bundle: {}
@@ -81,11 +73,11 @@ describe('Plugin', function () {
         });
 
         it('only files within a "lang" directory are considered', function () {
-            evt.file.fullPath = 'lang';
+            evt.file.fullPath = 'path/to/lang/foo.json';
             new Plugin().fileUpdated(evt, api);
             assert.equal(Object.keys(evt.bundle.lang).length, 1);
 
-            evt.file.fullPath = 'notlang';
+            evt.file.fullPath = 'path/to/notlang/something.json';
             new Plugin().fileUpdated(evt, api);
             assert.equal(Object.keys(evt.bundle.lang).length, 1);
         });
@@ -122,7 +114,7 @@ describe('Plugin', function () {
 
             evt = {
                 bundle: {
-                    bundleName: 'app',
+                    name: 'app',
                     lang: {
                         en: {
                             user: {
@@ -132,6 +124,9 @@ describe('Plugin', function () {
                             }
                         }
                     }
+                },
+                files: {
+                    "path/to/lang/user_en.json": {}
                 }
             };
 
@@ -171,6 +166,7 @@ describe('Plugin', function () {
             });
 
             it('allows whitelist bundle fallback', function () {
+                evt.files["path/to/lang/user_fr.json"] = {};
                 new Plugin({
                     whitelist: ['en', 'fr'],
                     format: FORMAT
@@ -186,6 +182,8 @@ describe('Plugin', function () {
                         foo: 'FOO-IN-FRENCH'
                     }
                 };
+                evt.files["path/to/lang/user_fr.json"] = {};
+                evt.files["path/to/lang/user_cu.json"] = {};
                 new Plugin({
                     whitelist: ['en', 'fr'],
                     format: FORMAT

--- a/tests/lib/plugin.js
+++ b/tests/lib/plugin.js
@@ -17,9 +17,8 @@ var FORMAT               = 'yui',
 describe('Plugin', function () {
 
     describe('in the constructor', function () {
-        beforeEach(function (done) {
+        beforeEach(function () {
             Plugin = require(modulepath);
-            done();
         });
 
         it('uses the config as options', function () {
@@ -27,6 +26,7 @@ describe('Plugin', function () {
                 instance = new Plugin(config);
 
             assert.strictEqual(instance.describe.options, config);
+            assert.strictEqual('en', config.defaultLang);
         });
     });
 
@@ -88,12 +88,6 @@ describe('Plugin', function () {
                 }
             };
 
-            Plugin.prototype.describe = {
-                options: {
-                    format: FORMAT
-                }
-            };
-
             done();
         });
 
@@ -105,40 +99,21 @@ describe('Plugin', function () {
         it('only files within a "lang" directory are considered', function () {
             evt.file.fullPath = 'lang';
             assert.strictEqual(
-                Plugin.prototype.fileUpdated(evt, api),
+                new Plugin().fileUpdated(evt, api),
                 PROMISE_RETURN_VALUE
             );
 
             evt.file.fullPath = 'notlang';
             assert.strictEqual(
-                Plugin.prototype.fileUpdated(evt, api),
+                new Plugin().fileUpdated(evt, api),
                 undefined
             );
         });
 
-        describe('the name of the build file', function () {
-            it('defaults to the "en" lang tag', function () {
-                Plugin.prototype.fileUpdated(evt, api);
-                assert.equal(destinationPath, 'bundlename-lang-filename_en.js');
-            });
-
-            it('allows for a configurable default lang tag', function () {
-                Plugin.prototype.describe.options.defaultLang = 'ja-JP';
-                Plugin.prototype.fileUpdated(evt, api);
-                assert.equal(destinationPath, 'bundlename-lang-filename_ja-JP.js');
-            });
-
-            it('prioritizes the lang tag in the file name over any defaults', function () {
-                Plugin.prototype.describe.options.defaultLang = 'ja-JP';
-                evt.file.relativePath = 'filename_en-US';
-                Plugin.prototype.fileUpdated(evt, api);
-                assert.equal(destinationPath, 'bundlename-lang-filename_en-us.js');
-            });
-        });
-
         describe('after the bundle is generated', function () {
             it('the lang entries are made available in memory', function () {
-                Plugin.prototype.fileUpdated(evt, api);
+                new Plugin().fileUpdated(evt, api);
+                console.log(evt.bundle.lang);
                 assert.strictEqual(
                     evt.bundle.lang.en.filename,
                     LANG_ENTRIES
@@ -148,10 +123,105 @@ describe('Plugin', function () {
             it('the yrb parser is invoked for pres files', function () {
                 evt.file.ext = 'pres';
                 yrbInvoked = false;
-                Plugin.prototype.fileUpdated(evt, api);
+                new Plugin().fileUpdated(evt, api);
                 assert(yrbInvoked);
             });
         });
+    });
+
+    describe('in the bundleUpdated method', function () {
+
+        beforeEach(function (done) {
+            mockery.registerMock('fs', {
+                readFileSync: function () {
+                    return {
+                        toString: function () {}
+                    };
+                }
+            });
+            mockery.registerMock('path', {
+                basename: function (basename) {
+                    return basename;
+                },
+                dirname: function (dirname) {
+                    return dirname;
+                }
+            });
+            mockery.registerMock('json5', {
+                parse: function () {
+                    return LANG_ENTRIES;
+                }
+            });
+            mockery.registerMock('./yrb2json', function (yrb) {
+                yrbInvoked = true;
+            });
+            mockery.registerMock('./formats/' + FORMAT, function () {});
+
+            mockery.registerAllowable('../package.json');
+            mockery.registerAllowable(modulepath);
+
+            mockery.enable({ useCleanCache: true });
+            Plugin = require(modulepath);
+            mockery.disable();
+
+            evt = {
+                file: {
+                    ext: 'json',
+                    fullPath: 'lang',
+                    bundleName: 'bundlename',
+                    relativePath: 'filename'
+                },
+                bundle: {}
+            };
+
+            api = {
+                promise: function (callback) {
+                    callback();
+                    return PROMISE_RETURN_VALUE;
+                },
+                writeFileInBundle: function (bundleName, destination_path) {
+                    destinationPath = destination_path;
+                    return {
+                        then: function () {}
+                    };
+                }
+            };
+
+            done();
+        });
+
+        afterEach(function (done) {
+            mockery.deregisterAll();
+            done();
+        });
+
+
+        describe('the name of the build file', function () {
+            it('defaults to the "en" lang tag', function () {
+                new Plugin({
+                    format: FORMAT
+                }).bundleUpdated(evt, api);
+                assert.equal(destinationPath, 'bundlename-lang-filename_en.js');
+            });
+
+            it('allows for a configurable default lang tag', function () {
+                new Plugin({
+                    defaultLang: 'ja-JP',
+                    format: FORMAT
+                }).bundleUpdated(evt, api);
+                assert.equal(destinationPath, 'bundlename-lang-filename_ja-JP.js');
+            });
+
+            it('prioritizes the lang tag in the file name over any defaults', function () {
+                evt.file.relativePath = 'filename_en-US';
+                new Plugin({
+                    format: FORMAT,
+                    defaultLang: 'ja-JP'
+                }).bundleUpdated(evt, api);
+                assert.equal(destinationPath, 'bundlename-lang-filename_en-us.js');
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
This PR introduces a new configuration called `whitelist` to specify an array of required lang bundles. If this value is set, `locator-lang` will complete those lang bundles and/or entries in each bundle based on the `defaultLang`. Here is an example:

```
var Locator = require('locator'),
    LocatorLang = require('locator-lang'),
    loc = new Locator();

// using locator-lang plugin
loc.plug(new LocatorLang({
    defaultLang: 'en',
    whitelist: ['en', 'fr', 'es']
}));
```
- [x] tests
- [x] docs
