### PR TITLE
bugfix for `requiredLangs` to avoid getting into a funky state in locator

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@ Locator Lang Change History
 @NEXT@
 ------------------
 
+* PR #7: bugfix for `requiredLangs` to avoid getting into a funky state in locator when mixing this plugin with `locator-yui`, where meta modules will be generated multiple times.
+
 0.2.0 (2014-03-06)
 ------------------
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -44,15 +44,19 @@ function PluginClass(config) {
 
 PluginClass.prototype = {
 
-    fileUpdated: function (evt) {
+    fileUpdated: function (evt, api) {
 
-        var file = evt.file,
+        var my = this,
+            file = evt.file,
             bundle = evt.bundle,
-            source_path = file.fullPath,
-            filename = this._getLangBundleName(source_path),
-            transpiler = this.describe.options.transpiler,
+            bundleName = bundle.name,
+            filename = this._getLangBundleName(file.fullPath),
             defaultLang = this.describe.options.defaultLang,
+            requiredLangs = this.describe.options.requiredLangs,
+            format = this.describe.options.format,
+            formatter = format && require('./formats/' + format),
             langBundleName,
+            moduleName,
             match,
             lang;
 
@@ -63,157 +67,138 @@ PluginClass.prototype = {
 
         match = filename.match(LANG_TAG_RE);
         lang  = (match && match[0].slice(1)) || defaultLang;
+        moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase();
 
         // hoge_ja-JP => hoge
         langBundleName = filename.replace(LANG_TAG_RE, '');
 
-        return new Promise(function (fulfill) {
-            var langEntries,
-                source,
-                token;
+        // provisioning lang entries for server side use
+        bundle.lang = bundle.lang || {};
+        bundle.lang[defaultLang] = bundle.lang[defaultLang] || {};
+        bundle.lang[lang] = bundle.lang[lang] || {};
 
-            try {
-                source = libfs.readFileSync(source_path, 'utf8').toString();
-                if (file.ext === 'pres') {
-                    source = yrb2json(source);
-                }
-                langEntries = json5.parse(source);
-                // transpiler
-                if (transpiler) {
-                    transpiler = require('./transpilers/' + transpiler);
-                    for (token in langEntries) {
-                        if (langEntries.hasOwnProperty(token) && typeof langEntries[token] === 'string') {
-                            langEntries[token] = transpiler(langEntries[token]);
+        return new Promise(function (fulfill, reject) {
+            var promises = [],
+                langEntries,
+                defaultLangEntries,
+                destinationPath;
+
+            langEntries = my._getLangEntries(file.fullPath, file.ext);
+
+            if (requiredLangs) {
+                if (lang !== defaultLang) {
+                    defaultLangEntries = bundle.lang[defaultLang][langBundleName];
+                    if (!defaultLangEntries) {
+                        try {
+                            defaultLangEntries = my._getLangEntries(libpath.join(libpath.dirname(file.fullPath),
+                                    langBundleName + '.' + file.ext, file.ext));
+                        } catch (e1) {
+                            try {
+                                defaultLangEntries = my._getLangEntries(libpath.join(libpath.dirname(file.fullPath),
+                                        langBundleName + '_' + defaultLang + '.' + file.ext, file.ext));
+                            } catch (e2) {
+                                throw new Error('Error locating the default entries for lang bundle "' +
+                                        langBundleName + '" for bundle "' + bundleName + '"');
+                            }
                         }
                     }
-                }
-            } catch (e) {
-                throw new Error('Error parsing lang bundle: ' +
-                        file.relativePath, '. ' + (e.stack || e));
-            }
-            // provisioning lang entries for server side use
-            bundle.lang = bundle.lang || {};
-            bundle.lang[lang] = bundle.lang[lang] || {};
-            bundle.lang[lang][langBundleName] = langEntries;
+                    if (requiredLangs.indexOf(lang) >= 0) {
+                        if (my._completeLangEntries(langEntries, defaultLangEntries)) {
+                            debug('entries in lang bundle "%s" for lang "%s" were completed based on default lang "%s"',
+                                    langBundleName, lang, defaultLang);
+                        }
+                    }
+                } else {
+                    // complete missing lang bundles
+                    requiredLangs.forEach(function (lang) {
+                        var sourcePath;
 
-            fulfill();
+                        bundle.lang[lang] = bundle.lang[lang] || {};
+                        if ((lang === defaultLang) || (bundle.lang[lang][langBundleName])) {
+                            return; // not need to complete
+                        }
+
+                        sourcePath = libpath.join(libpath.dirname(file.fullPath), langBundleName + '_' + lang + '.' + file.ext);
+                        try {
+                            bundle.lang[lang][langBundleName] = my._getLangEntries(sourcePath, file.ext);
+                        } catch (e2) {
+                            debug('all entries in lang bundle "%s" for lang "%s" were completed ' +
+                                    'based on default lang "%s"', langBundleName, lang, defaultLang);
+                            bundle.lang[lang][langBundleName] = langEntries;
+                            destinationPath = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
+                            // writting file to disk
+                            promises.push(api.writeFileInBundle(
+                                bundleName,
+                                destinationPath,
+                                formatter(bundleName, langBundleName,
+                                    (bundleName + '-lang-' + langBundleName + '_' + lang).toLocaleLowerCase(), langEntries, lang)
+                            ));
+                        }
+                    });
+                }
+            }
+
+            bundle.lang[lang][langBundleName] = langEntries;
+            destinationPath = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
+            // writting file to disk
+            promises.push(api.writeFileInBundle(
+                bundleName,
+                destinationPath,
+                formatter(bundleName, langBundleName, moduleName, langEntries, lang)
+            ));
+
+            return Promise.all(promises).then(fulfill, reject);
         });
 
     },
 
-    bundleUpdated: function (evt, api) {
-        var bundle = evt.bundle,
-            bundleName = bundle.name,
-            format = this.describe.options.format,
-            formatter = require('./formats/' + format),
-            defaultLang = this.describe.options.defaultLang,
-            promises = [],
-            files = [];
+    _getLangEntries: function (file, ext) {
+        var transpiler = this.describe.options.transpiler,
+            source,
+            langEntries,
+            token;
 
-        if (!bundle.lang) {
-            return; // no lang bundle to be process
-        }
-
-        Object.keys(evt.files).forEach(function (file) {
-            file = this._getLangBundleName(file);
-            if (file) {
-                files.push(file);
+        try {
+            source = libfs.readFileSync(file, 'utf8').toString();
+            if (ext === 'pres') {
+                source = yrb2json(source);
             }
-        }, this);
-
-        if (files.length === 0) {
-            return; // no lang bundle where changed
-        }
-        files = files.concat(this._completeMissing(bundle));
-
-        Object.keys(bundle.lang).forEach(function (lang) {
-
-            Object.keys(bundle.lang[lang]).forEach(function (langBundleName) {
-
-                var filename,
-                    moduleName,
-                    destinationPath;
-
-                if (files.indexOf(langBundleName + '_' + lang) >= 0) {
-                    filename = langBundleName + '_' + lang;
-                } else if (lang === defaultLang && files.indexOf(langBundleName) >= 0) {
-                    filename = langBundleName;
-                } else {
-                    return; // nothing to write since the lang bundle is not changed in this evt
+            langEntries = json5.parse(source);
+            // transpiler
+            if (transpiler) {
+                transpiler = require('./transpilers/' + transpiler);
+                for (token in langEntries) {
+                    if (langEntries.hasOwnProperty(token) && typeof langEntries[token] === 'string') {
+                        langEntries[token] = transpiler(langEntries[token]);
+                    }
                 }
+            }
+        } catch (e) {
+            throw new Error('Error parsing lang bundle: ' +
+                    file, '. ' + (e.stack || e));
+        }
+        return langEntries;
+    },
 
-                moduleName = (bundleName + '-lang-' + filename).toLocaleLowerCase(),
-                destinationPath = (bundleName + '-lang-' + langBundleName) + '_' + lang + '.js';
+    _completeLangEntries: function (langEntries, defaultLangEntries) {
+        var token,
+            completed;
 
-                debug('writting [%s] in lang "%s"', destinationPath, lang);
-                // trying to write the destination file which the content of the lang bundle
-                promises.push(api.writeFileInBundle(
-                    bundleName,
-                    destinationPath,
-                    formatter(bundleName, langBundleName, moduleName, bundle.lang[lang][langBundleName], lang)
-                ));
-
-            });
-
-        });
+        for (token in defaultLangEntries) {
+            if (defaultLangEntries.hasOwnProperty(token)) {
+                if (!langEntries[token]) {
+                    completed = true;
+                    langEntries[token] = defaultLangEntries[token];
+                }
+            }
+        }
+        return completed;
     },
 
     _getLangBundleName: function (file) {
         var name = libpath.basename(file, libpath.extname(file));
         // only files within the lang folder will be evaluated as lang bundles
         return (libpath.basename(libpath.dirname(file)) === 'lang') && name;
-    },
-
-    _completeMissing: function (bundle) {
-        var requiredLangs = this.describe.options.requiredLangs,
-            defaultLang = this.describe.options.defaultLang,
-            files = [];
-
-        if (requiredLangs) {
-            requiredLangs.forEach(function (lang) {
-
-                var defaultLangBundle = bundle.lang[defaultLang],
-                    token,
-                    bundleName;
-
-                if (!bundle.lang[lang]) {
-                    debug('entire locale is missing for lang "%s"', lang);
-                    bundle.lang[lang] = {};
-                }
-
-                for (bundleName in defaultLangBundle) {
-                    if (defaultLangBundle.hasOwnProperty(bundleName)) {
-
-                        if (!bundle.lang[lang][bundleName]) {
-                            debug('lang bundle "%s" is missing for lang "%s", replicating from default "%s"', bundleName, lang, defaultLang);
-                            bundle.lang[lang][bundleName] = defaultLangBundle[bundleName];
-                            files.push(bundleName + '_' + lang);
-                            continue;
-                        }
-
-                        // simple process to avoid completing over and over again
-                        if (bundle.lang[lang][bundleName]['@expanded']) {
-                            continue;
-                        }
-                        Object.defineProperty(bundle.lang[lang][bundleName], '@expanded', { value: true });
-
-                        for (token in defaultLangBundle[bundleName]) {
-                            if (defaultLangBundle[bundleName].hasOwnProperty(token)) {
-
-                                if (!bundle.lang[lang][bundleName][token]) {
-                                    debug('lang entry "%s" is missing in bundle "%s" for lang "%s",' +
-                                          ' replicating from default "%s"', token, bundleName, lang, defaultLang);
-                                    bundle.lang[lang][bundleName][token] = defaultLangBundle[bundleName][token];
-                                }
-                            }
-                        }
-
-                    }
-                }
-
-            });
-        }
-        return files;
     }
 
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -72,6 +72,11 @@ PluginClass.prototype = {
         // hoge_ja-JP => hoge
         langBundleName = filename.replace(LANG_TAG_RE, '');
 
+        // if requiredLangs is set, only files in those langs will be analyzed
+        if (requiredLangs && requiredLangs.indexOf(lang) === -1) {
+            return;
+        }
+
         // provisioning lang entries for server side use
         bundle.lang = bundle.lang || {};
         bundle.lang[defaultLang] = bundle.lang[defaultLang] || {};
@@ -91,11 +96,11 @@ PluginClass.prototype = {
                     if (!defaultLangEntries) {
                         try {
                             defaultLangEntries = my._getLangEntries(libpath.join(libpath.dirname(file.fullPath),
-                                    langBundleName + '.' + file.ext, file.ext));
+                                    langBundleName + '.' + file.ext), file.ext);
                         } catch (e1) {
                             try {
                                 defaultLangEntries = my._getLangEntries(libpath.join(libpath.dirname(file.fullPath),
-                                        langBundleName + '_' + defaultLang + '.' + file.ext, file.ext));
+                                        langBundleName + '_' + defaultLang + '.' + file.ext), file.ext);
                             } catch (e2) {
                                 throw new Error('Error locating the default entries for lang bundle "' +
                                         langBundleName + '" for bundle "' + bundleName + '"');

--- a/tests/fixtures/lang/fallback.pres
+++ b/tests/fixtures/lang/fallback.pres
@@ -1,0 +1,2 @@
+FOO=foo in english
+BAR=bar in english

--- a/tests/fixtures/lang/fallback_fr.pres
+++ b/tests/fixtures/lang/fallback_fr.pres
@@ -1,0 +1,1 @@
+FOO=foo in french

--- a/tests/fixtures/lang/filename.json
+++ b/tests/fixtures/lang/filename.json
@@ -1,0 +1,3 @@
+{
+	FOO: "foo in english"
+}


### PR DESCRIPTION
bugfix for `requiredLangs` to avoid getting into a funky state in locator when mixing this plugin with `locator-yui`, where meta modules will be generated multiple times.
